### PR TITLE
[MT-657] Split into base js config and optional ember config, streamline.

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,0 +1,3 @@
+module.exports = {
+    extends: 'mariana'
+}

--- a/ember.js
+++ b/ember.js
@@ -1,0 +1,28 @@
+module.exports = {
+  extends: [
+    'mariana',
+    'plugin:ember/recommended'
+  ],
+  globals: {
+    c3: true,
+    server: true
+  },
+  plugins: [
+    'ember'
+  ],
+  rules: {
+    // eslint-config-ember
+    // https://github.com/jonathanKingston/eslint-config-ember
+    'no-underscore-dangle': 0,
+    'prefer-rest-params': 0,
+    'prefer-template': 0,
+
+    // eslint-plugin-ember rules
+    // https://github.com/ember-cli/eslint-plugin-ember
+    'ember/order-in-components': 'error',
+    'ember/order-in-controllers': 'error',
+    'ember/order-in-models': 'error',
+    'ember/order-in-routes': 'error',
+    'ember/use-ember-get-and-set': 'error'
+  }
+}

--- a/index.js
+++ b/index.js
@@ -1,45 +1,28 @@
 module.exports = {
-    extends: 'airbnb-base',
-    rules: {
-        'array-callback-return': 0,
-        'arrow-body-style': [0, 'as-needed'],
-        'arrow-parens': 0,
-        'arrow-spacing': 0,
-        'comma-dangle': [1, 'never'],
-        'consistent-return': [2],
-        'curly': [2, 'multi-line'],
-        'dot-notation': [2, { 'allowPattern': '^[a-z]+(-[a-z]+)+$' }],
-        'eol-last': [2],
-        'func-names': 0, // TODO: change to 2 and name all functions for the call stack
-        'import/extensions': [0],
-        'import/first': 0, // off because we import alphabetically
-        'import/no-extraneous-dependencies': 0,
-        'import/no-unresolved': [0],
-        'indent': [2, 4, { 'SwitchCase': 1 }],
-        'max-len': [2, 120, 4, { 'ignoreComments': true, 'ignoreUrls': true }],
-        'newline-after-var': 'error',
-        'newline-per-chained-call': 0,
-        'no-console': [0],
-        'no-magic-numbers': 0,
-        'no-multiple-empty-lines': ['error', { 'max': 1 }],
-        'no-plusplus': 0,
-        'no-underscore-dangle': 0,
-        'no-mixed-spaces-and-tabs': 2,
-        'no-param-reassign': [2, { 'props': false }],
-        'object-curly-spacing': [0, 'always'],
-        'object-shorthand': 'error',
-        'one-var': [0, 'always'], // TODO: change to 2 and use one var,
-        'sort-imports': 'error',
-        'space-after-function-name': 0,
-        'space-before-function-name': 0,
-        'space-before-function-paren': 0,
-        'space-after-function-paren': 0,
-        'space-in-brackets': [0, 'never'],
-        'space-in-parens': [0, 'never'],
-        'spaced-comment': 1,
-        'wrap-regex': 2,
-        'quotes': [2, 'single'],
-        'linebreak-style': [2, 'unix'],
-        'semi': [2, 'always']
-    }
+  env: {
+      browser: true
+  },
+  extends: [
+    'airbnb-base',
+    'plugin:compat/recommended'
+  ],
+  parserOptions: {
+      ecmaVersion: 2018,
+      sourceType: 'module'
+  },
+  plugins: [
+      'compat'
+  ],
+  rules: {
+    'camelcase': [0, { 'properties': 'never' }], // we use underscore sometimes
+    'import/no-unresolved': [0], // tbd
+    'import/order': [0], // off due to use of sort-order
+    'sort-imports': 'error', // currently all projects sorted using this
+    'space-in-brackets': [0, 'never'], // seems excessive
+    'space-in-parens': [0, 'never'], // javascript is a strange bedfellow
+
+    // TODO: keep until all other fixes in place.
+    'indent': [2, 4, { 'SwitchCase': 1 }],
+    'max-len': [2, 120, 4, { 'ignoreComments': true, 'ignoreUrls': true }],
+  }
 };

--- a/package.json
+++ b/package.json
@@ -1,12 +1,13 @@
 {
   "name": "eslint-config-mariana",
-  "version": "1.0.1",
-  "description": "a mariana airbnb override",
-  "main": "index.js",
+  "version": "2.0.0",
+  "description": "MarianaTek's base eslint config for javascript projects.",
   "repository": "https://github.com/Mariana-Tek/eslint-config-mariana",
   "private": true,
-  "peerDependencies": {
-    "eslint": "^4.7.2",
-    "eslint-config-airbnb-base": "^11.3.2"
+  "dependencies": {
+    "eslint": "^4.19.1",
+    "eslint-config-airbnb-base": "^13.0.0",
+    "eslint-plugin-compat": "^2.4.0",
+    "eslint-plugin-import": "^2.13.0"
   }
 }


### PR DESCRIPTION
- Separates the config into a base javascript-only version and an ember version.
- Removes redundant declarations.
- Removes most existing rules in favor of defaults including from plugins*.

(TBD which rules stay)